### PR TITLE
UI refresh: neutral surfaces, softer borders, focus rings, calendar & meal library

### DIFF
--- a/app/calendar/add-meal-modal.tsx
+++ b/app/calendar/add-meal-modal.tsx
@@ -7,6 +7,7 @@ import { supabase } from '@/lib/supabase'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
 import { MEAL_CATEGORIES } from '@/app/meals/meal-utils'
+import { Chip } from '@/components/ui/chip'
 import {
   Select,
   SelectContent,
@@ -105,10 +106,9 @@ export function AddMealModal({ open, onOpenChange, groupId, date, onMealAdded }:
                 placeholder="Search meals..."
                 value={searchTerm}
                 onChange={(e) => setSearchTerm(e.target.value)}
-                className="bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
               />
               <Select value={selectedCategory} onValueChange={setSelectedCategory}>
-                <SelectTrigger className="bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20">
+                <SelectTrigger>
                   <SelectValue placeholder="All categories" />
                 </SelectTrigger>
                 <SelectContent>
@@ -126,17 +126,17 @@ export function AddMealModal({ open, onOpenChange, groupId, date, onMealAdded }:
               {filteredMeals.map((meal) => (
                 <div
                   key={meal.id}
-                  className={`p-3 rounded-lg border cursor-pointer hover:bg-[#98C1B2]/5 ${
-                    selectedMealId === meal.id ? 'border-[#98C1B2] bg-[#98C1B2]/10' : 'border-[#98C1B2]/30'
+                  className={`rounded-[10px] border border-border/60 bg-card p-3 cursor-pointer transition-colors hover:bg-surface-2/60 ${
+                    selectedMealId === meal.id ? 'border-primary/50 bg-primary/5' : ''
                   }`}
                   onClick={() => setSelectedMealId(meal.id)}
                 >
                   <div className="flex items-center justify-between">
                     <h3 className="font-medium">{meal.name}</h3>
                     {meal.category && (
-                      <span className="text-xs px-2 py-1 rounded-full bg-[#98C1B2]/10 text-[#2F4F4F]">
+                      <Chip className="bg-surface-2 text-muted-foreground">
                         {meal.category}
-                      </span>
+                      </Chip>
                     )}
                   </div>
                 </div>

--- a/app/calendar/add-meal-modal.tsx
+++ b/app/calendar/add-meal-modal.tsx
@@ -6,8 +6,9 @@ import { Button } from '@/components/ui/button'
 import { supabase } from '@/lib/supabase'
 import { toast } from 'sonner'
 import { Input } from '@/components/ui/input'
-import { MEAL_CATEGORIES } from '@/app/meals/meal-utils'
+import { MEAL_CATEGORIES, MealCategory, getCategoryColor } from '@/app/meals/meal-utils'
 import { Chip } from '@/components/ui/chip'
+import { cn } from '@/lib/utils'
 import {
   Select,
   SelectContent,
@@ -134,7 +135,7 @@ export function AddMealModal({ open, onOpenChange, groupId, date, onMealAdded }:
                   <div className="flex items-center justify-between">
                     <h3 className="font-medium">{meal.name}</h3>
                     {meal.category && (
-                      <Chip className="bg-surface-2 text-muted-foreground">
+                      <Chip className={cn("text-xs", getCategoryColor(meal.category as MealCategory))}>
                         {meal.category}
                       </Chip>
                     )}

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -3,7 +3,9 @@
 import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
-import { ChevronLeft, ChevronRight, Dice5, PlusCircle, Trash2 } from "lucide-react"
+import { IconButton } from "@/components/ui/icon-button"
+import { Chip } from "@/components/ui/chip"
+import { ChevronLeft, ChevronRight, Dice5, Plus, Trash2 } from "lucide-react"
 import {
   format,
   addMonths,
@@ -382,19 +384,22 @@ export default function CalendarPage() {
 
   if (isAuthChecking) {
     return (
-      <div className="min-h-screen bg-[#F5E6D3] p-6 flex items-center justify-center">
-        <div className="w-16 h-16 rounded-full animate-pulse bg-gray-200" />
+      <div className="min-h-screen bg-background p-5 flex items-center justify-center">
+        <div className="w-16 h-16 rounded-full animate-pulse bg-surface-2" />
       </div>
     )
   }
 
   return (
-    <div className="min-h-screen bg-[#F5E6D3] p-6 space-y-6">
-      <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-        <h1 className="text-3xl font-bold tracking-tight text-[#2F4F4F]">Meal Calendar</h1>
-        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-4">
+    <div className="min-h-screen space-y-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight text-foreground">Meal Calendar</h1>
+          <p className="text-sm text-muted-foreground">Plan meals for your household calendar.</p>
+        </div>
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
           <Select value={selectedGroupId} onValueChange={setSelectedGroupId}>
-            <SelectTrigger className="w-[200px] bg-white/80 backdrop-blur border-[#98C1B2] text-[#2F4F4F]">
+            <SelectTrigger className="w-full sm:w-[220px] bg-card">
               <SelectValue placeholder="Select a group" />
             </SelectTrigger>
             <SelectContent>
@@ -411,7 +416,8 @@ export default function CalendarPage() {
             <Button
               onClick={handleGenerateList}
               data-grocery-button
-              className="bg-[#FF9B76] hover:bg-[#FF9B76]/90 text-white font-medium px-6 py-2 rounded-full shadow-md hover:shadow-lg transition-all duration-200"
+              variant="secondary"
+              className="w-full sm:w-auto"
             >
               Generate Grocery List
             </Button>
@@ -419,33 +425,34 @@ export default function CalendarPage() {
         </div>
       </div>
 
-      <div className="rounded-2xl border border-[#98C1B2] bg-white/80 backdrop-blur shadow-lg">
-        <div className="p-4 sm:p-6">
-          <div className="flex items-center justify-between mb-8">
-            <Button 
-              variant="ghost" 
+      <div className="rounded-xl border border-border/60 bg-card shadow-sm">
+        <div className="p-4 sm:p-5">
+          <div className="flex items-center justify-between gap-3 mb-4">
+            <IconButton
+              aria-label="Go to previous month"
               onClick={() => {
                 if (window.innerWidth >= 640) {
                   handlePrevMonth()
                 } else {
                   handlePrevWeek()
                 }
-              }} 
+              }}
               disabled={isMonthLoading}
-              className="shrink-0 px-1 sm:px-4"
             >
               <ChevronLeft className="h-5 w-5" />
-            </Button>
-            <h2 className="text-base sm:text-2xl font-semibold text-[#2F4F4F] mx-2 truncate">
-              <span className="hidden sm:inline">
-                {format(currentDate, "MMMM yyyy")}
-              </span>
-              <span className="sm:hidden">
-                {format(mobileWeekStart, "MMM d")} - {format(endOfWeek(mobileWeekStart), "MMM d")}
-              </span>
-            </h2>
-            <Button 
-              variant="ghost" 
+            </IconButton>
+            <div className="flex-1 text-center">
+              <h2 className="text-lg sm:text-xl font-semibold text-foreground truncate">
+                <span className="hidden sm:inline">
+                  {format(currentDate, "MMMM yyyy")}
+                </span>
+                <span className="sm:hidden">
+                  {format(mobileWeekStart, "MMM d")} - {format(endOfWeek(mobileWeekStart), "MMM d")}
+                </span>
+              </h2>
+            </div>
+            <IconButton
+              aria-label="Go to next month"
               onClick={() => {
                 if (window.innerWidth >= 640) {
                   handleNextMonth()
@@ -454,84 +461,100 @@ export default function CalendarPage() {
                 }
               }}
               disabled={isMonthLoading}
-              className="shrink-0 px-1 sm:px-4"
             >
               <ChevronRight className="h-5 w-5" />
-            </Button>
+            </IconButton>
           </div>
 
           <div className="hidden sm:block">
-            <div className="grid grid-cols-7 gap-px bg-[#98C1B2]/20 rounded-lg overflow-hidden relative">
+            <div className="grid grid-cols-7 border border-border/60 rounded-lg overflow-hidden relative">
               {isMonthLoading && (
-                <div className="absolute inset-0 bg-white/80 z-10 transition-opacity duration-200" />
+                <div className="absolute inset-0 bg-background/80 z-10 transition-opacity duration-200" />
               )}
               {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((dayName) => (
-                <div key={dayName} className="bg-[#98C1B2]/10 p-3 text-center text-sm font-medium text-[#2F4F4F]">
+                <div
+                  key={dayName}
+                  className="bg-surface-2 p-2 text-center text-xs font-semibold text-muted-foreground border-b border-r border-border/60 last:border-r-0"
+                >
                   {dayName}
                 </div>
               ))}
               {days.map((day) => {
                 const dateStr = format(day, "yyyy-MM-dd")
                 const meal = calendarMeals[dateStr]
+                const isOutsideMonth = !isSameMonth(day, currentDate)
+                const isToday = isSameDay(day, new Date())
+                const isSingleSelection = !!dateRange.start && (!dateRange.end || (dateRange.end && isSameDay(dateRange.start, dateRange.end)))
+                const mealsForDay = meal ? [meal] : []
 
                 return (
                   <div
                     key={dateStr}
                     data-day
                     onClick={(e) => handleDateClick(day, e)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        handleDateClick(day, e as unknown as React.MouseEvent)
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`Select ${format(day, "MMMM d, yyyy")}`}
                     className={cn(
-                      "min-h-[100px] sm:min-h-[120px] p-3 bg-white relative cursor-pointer",
-                      !isSameMonth(day, currentDate) && "text-muted-foreground",
-                      meal && "bg-[#98C1B2]/10",
-                      isDateInRange(day) && [
-                        "relative z-10",
-                        // If it's a single day selection (no end date) or start and end are the same day
-                        (!dateRange.end || (dateRange.end && isSameDay(dateRange.start!, dateRange.end))) && "border-2 border-[#FF9B76]",
-                        // If it's part of a range (has end date)
-                        dateRange.end && [
-                          "border-t-2 border-b-2 border-[#FF9B76]",
-                          isRangeStart(day) && "border-l-2 border-[#FF9B76]",
-                          isRangeEnd(day) && "border-r-2 border-[#FF9B76]",
-                        ]
-                      ]
+                      "group min-h-[92px] sm:min-h-[108px] border-b border-r border-border/60 p-2.5 bg-card relative cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                      isOutsideMonth && "text-muted-foreground/60",
+                      meal && "bg-surface-2/50",
+                      isDateInRange(day) && "bg-primary/5",
+                      isSingleSelection && dateRange.start && isSameDay(day, dateRange.start) && "ring-2 ring-primary/40",
+                      dateRange.end && isRangeStart(day) && "ring-2 ring-primary/40",
+                      dateRange.end && isRangeEnd(day) && "ring-2 ring-primary/40",
+                      !meal && "hover:bg-surface-2/60",
+                      meal && "hover:bg-surface-2/70"
                     )}
                   >
-                    <div className="flex justify-between items-start">
-                      <span className="text-sm font-medium">
+                    <div className="flex justify-between items-start gap-2">
+                      <span
+                        className={cn(
+                          "text-xs font-medium text-muted-foreground",
+                          isToday && "rounded-full bg-primary/10 px-2 py-0.5 text-primary",
+                          isOutsideMonth && "text-muted-foreground/50"
+                        )}
+                      >
                         {format(day, "d")}
                       </span>
                       {selectedGroupId && (
-                        <div className="flex items-center gap-1">
+                        <div className="opacity-0 group-hover:opacity-100 group-focus-within:opacity-100 transition flex items-center gap-2">
                           {meal ? (
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-7 w-7 text-red-500 hover:text-red-600"
+                            <IconButton
+                              aria-label={`Remove meal on ${format(day, "MMMM d")}`}
+                              variant="destructive"
                               onClick={(e) => {
                                 e.stopPropagation()
                                 deleteMeal(dateStr)
                               }}
                             >
                               <Trash2 className="h-4 w-4" />
-                            </Button>
+                            </IconButton>
                           ) : (
                             <>
                               <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-7 w-7"
+                                variant="secondary"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
                                 onClick={(e) => {
                                   e.stopPropagation()
                                   setSelectedDate(day)
                                   setShowAddMeal(true)
                                 }}
+                                aria-label={`Add meal on ${format(day, "MMMM d")}`}
                               >
-                                <PlusCircle className="h-4 w-4" />
+                                <Plus className="h-3.5 w-3.5" />
+                                <span className="hidden lg:inline">Add meal</span>
                               </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-7 w-7"
+                              <IconButton
+                                aria-label={`Add random meal on ${format(day, "MMMM d")}`}
+                                variant="subtle"
                                 disabled={randomizingDate === dateStr}
                                 onClick={(e) => {
                                   e.stopPropagation()
@@ -539,21 +562,31 @@ export default function CalendarPage() {
                                 }}
                               >
                                 <Dice5 className="h-4 w-4" />
-                              </Button>
+                              </IconButton>
                             </>
                           )}
                         </div>
                       )}
                     </div>
                     
-                    {meal && (
-                      <div className={cn(
-                        "mt-1 p-2 rounded-md",
-                        getCategoryColor(meal.category as MealCategory)
-                      )}>
-                        <div className="text-sm font-medium">
-                          {meal.name}
-                        </div>
+                    {mealsForDay.length > 0 && (
+                      <div className="mt-2 space-y-1">
+                        {mealsForDay.slice(0, 3).map((mealItem, index) => (
+                          <Chip
+                            key={mealItem.id}
+                            className={cn(
+                              "w-full justify-start truncate text-xs font-medium",
+                              getCategoryColor(mealItem.category as MealCategory),
+                              index === 2 && "hidden lg:inline-flex",
+                              isOutsideMonth && "opacity-60"
+                            )}
+                          >
+                            {mealItem.name}
+                          </Chip>
+                        ))}
+                        {mealsForDay.length > 3 && (
+                          <span className="text-xs text-muted-foreground">+{mealsForDay.length - 3} more</span>
+                        )}
                       </div>
                     )}
                   </div>
@@ -565,7 +598,7 @@ export default function CalendarPage() {
           <div className="sm:hidden">
             <div className="flex flex-col gap-2 relative">
               {isMonthLoading && (
-                <div className="absolute inset-0 bg-white/80 z-10 transition-opacity duration-200" />
+                <div className="absolute inset-0 bg-background/80 z-10 transition-opacity duration-200" />
               )}
               {mobileDays.map((day) => {
                 const dateStr = format(day, "yyyy-MM-dd")
@@ -576,54 +609,60 @@ export default function CalendarPage() {
                     key={day.toISOString()}
                     data-day
                     onClick={(e) => handleDateClick(day, e)}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault()
+                        handleDateClick(day, e as unknown as React.MouseEvent)
+                      }
+                    }}
+                    tabIndex={0}
+                    role="button"
+                    aria-label={`Select ${format(day, "MMMM d, yyyy")}`}
                     className={cn(
-                      "p-4 bg-white rounded-lg border border-[#98C1B2]/30",
-                      "hover:bg-[#98C1B2]/5",
-                      meal && "bg-[#98C1B2]/10",
-                      isDateInRange(day) && "ring-2 ring-[#FF9B76] z-10"
+                      "p-3 bg-card rounded-xl border border-border/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
+                      "hover:bg-surface-2/60",
+                      meal && "bg-surface-2/50",
+                      isDateInRange(day) && "ring-2 ring-primary/40 z-10"
                     )}
                   >
-                    <div className="flex justify-between items-start">
+                    <div className="flex justify-between items-start gap-2">
                       <div className="flex items-center gap-2">
-                        <span className="text-lg font-medium">
+                        <span className="text-sm font-semibold">
                           {format(day, "EEE")}
                         </span>
-                        <span className="text-sm text-muted-foreground">
+                        <span className="text-xs text-muted-foreground">
                           {format(day, "MMM d")}
                         </span>
                       </div>
                       {selectedGroupId && (
-                        <div className="flex items-center gap-1">
+                        <div className="flex items-center gap-2">
                           {meal ? (
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-8 w-8 text-red-500 hover:text-red-600"
+                            <IconButton
+                              aria-label={`Remove meal on ${format(day, "MMMM d")}`}
+                              variant="destructive"
                               onClick={(e) => {
                                 e.stopPropagation()
                                 deleteMeal(dateStr)
                               }}
                             >
                               <Trash2 className="h-4 w-4" />
-                            </Button>
+                            </IconButton>
                           ) : (
                             <>
-                              <Button
+                              <IconButton
+                                aria-label={`Add meal on ${format(day, "MMMM d")}`}
                                 variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
                                 onClick={(e) => {
                                   e.stopPropagation()
                                   setSelectedDate(day)
                                   setShowAddMeal(true)
                                 }}
                               >
-                                <PlusCircle className="h-4 w-4" />
-                              </Button>
-                              <Button
-                                variant="ghost"
-                                size="icon"
-                                className="h-8 w-8"
+                                <Plus className="h-4 w-4" />
+                              </IconButton>
+                              <IconButton
+                                aria-label={`Add random meal on ${format(day, "MMMM d")}`}
+                                variant="subtle"
                                 disabled={randomizingDate === dateStr}
                                 onClick={(e) => {
                                   e.stopPropagation()
@@ -631,7 +670,7 @@ export default function CalendarPage() {
                                 }}
                               >
                                 <Dice5 className="h-4 w-4" />
-                              </Button>
+                              </IconButton>
                             </>
                           )}
                         </div>
@@ -639,13 +678,10 @@ export default function CalendarPage() {
                     </div>
                     
                     {meal && (
-                      <div className={cn(
-                        "mt-2 p-2 rounded-md",
-                        getCategoryColor(meal.category as MealCategory)
-                      )}>
-                        <div className="text-sm font-medium">
+                      <div className="mt-2">
+                        <Chip className={cn("w-full justify-start truncate", getCategoryColor(meal.category as MealCategory))}>
                           {meal.name}
-                        </div>
+                        </Chip>
                       </div>
                     )}
                   </div>

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -25,10 +25,10 @@ export function Navbar() {
   ]
 
   return (
-    <nav className="border-b bg-white">
+    <nav className="border-b border-border/60 bg-card/90 backdrop-blur">
       <div className="max-w-7xl mx-auto px-4">
         <div className="flex items-center justify-between h-16">
-          <Link href="/" className="text-xl font-semibold text-[#2F4F4F]">
+          <Link href="/" className="text-xl font-semibold text-foreground">
             Pantry Planner
           </Link>
 
@@ -39,9 +39,9 @@ export function Navbar() {
                 key={item.href}
                 href={item.href}
                 className={cn(
-                  'text-sm font-medium transition-colors hover:text-[#2F4F4F]',
+                  'text-sm font-medium transition-colors hover:text-foreground',
                   pathname === item.href
-                    ? 'text-[#2F4F4F]'
+                    ? 'text-foreground'
                     : 'text-muted-foreground'
                 )}
               >

--- a/app/globals.css
+++ b/app/globals.css
@@ -8,52 +8,54 @@ body {
 
 @layer base {
   :root {
-    --background: 39 38% 89%; /* #F5E6D3 */
-    --foreground: 180 25% 25%; /* #2F4F4F */
+    --background: 30 20% 97%; /* #F7F5F1 */
+    --foreground: 215 16% 18%; /* #2A2E33 */
     --card: 0 0% 100%;
-    --card-foreground: 180 25% 25%;
+    --card-foreground: 215 16% 18%;
     --popover: 0 0% 100%;
-    --popover-foreground: 180 25% 25%;
-    --primary: 164 23% 68%; /* #98C1B2 */
-    --primary-foreground: 180 25% 25%;
-    --secondary: 164 23% 95%;
-    --secondary-foreground: 180 25% 25%;
-    --muted: 164 23% 95%;
-    --muted-foreground: 180 25% 45%;
-    --accent: 17 100% 73%; /* #FF9B76 */
+    --popover-foreground: 215 16% 18%;
+    --surface-2: 30 17% 93%; /* #F1EEEA */
+    --primary: 162 35% 33%; /* #2F6F5C */
+    --primary-foreground: 0 0% 100%;
+    --secondary: 30 17% 93%;
+    --secondary-foreground: 215 16% 18%;
+    --muted: 30 17% 93%;
+    --muted-foreground: 215 10% 45%;
+    --accent: 18 86% 62%; /* #F28B66 */
     --accent-foreground: 0 0% 100%;
     --destructive: 0 84% 60%;
     --destructive-foreground: 0 0% 98%;
-    --border: 164 23% 68%; /* #98C1B2 */
-    --input: 164 23% 68%;
-    --ring: 17 100% 73%;
+    --border: 30 12% 85%; /* #E2DDD5 */
+    --input: 30 12% 85%;
+    --ring: 162 35% 33%;
     --chart-1: 12 76% 61%;
     --chart-2: 173 58% 39%;
     --chart-3: 197 37% 24%;
     --chart-4: 43 74% 66%;
     --chart-5: 27 87% 67%;
-    --radius: 1rem;
+    --radius: 12px;
   }
   .dark {
-    --background: 180 25% 10%;
-    --foreground: 39 38% 89%;
-    --card: 180 25% 15%;
-    --card-foreground: 39 38% 89%;
-    --popover: 180 25% 15%;
-    --popover-foreground: 39 38% 89%;
-    --primary: 164 23% 48%;
-    --primary-foreground: 180 25% 98%;
-    --secondary: 164 23% 25%;
-    --secondary-foreground: 39 38% 89%;
-    --muted: 164 23% 25%;
-    --muted-foreground: 39 38% 70%;
-    --accent: 17 100% 63%;
+    --background: 215 18% 10%;
+    --foreground: 30 20% 93%;
+    --card: 215 18% 14%;
+    --card-foreground: 30 20% 93%;
+    --popover: 215 18% 14%;
+    --popover-foreground: 30 20% 93%;
+    --surface-2: 215 16% 18%;
+    --primary: 162 30% 45%;
+    --primary-foreground: 0 0% 100%;
+    --secondary: 215 16% 18%;
+    --secondary-foreground: 30 20% 93%;
+    --muted: 215 16% 18%;
+    --muted-foreground: 30 15% 70%;
+    --accent: 18 80% 55%;
     --accent-foreground: 0 0% 100%;
     --destructive: 0 62% 30%;
     --destructive-foreground: 0 0% 98%;
-    --border: 164 23% 48%;
-    --input: 164 23% 48%;
-    --ring: 17 100% 63%;
+    --border: 215 12% 28%;
+    --input: 215 12% 28%;
+    --ring: 162 30% 45%;
     --chart-1: 220 70% 50%;
     --chart-2: 160 60% 45%;
     --chart-3: 30 80% 55%;
@@ -67,7 +69,7 @@ body {
     @apply border-border;
   }
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background text-foreground text-sm;
     font-feature-settings: "rlig" 1, "calt" 1;
   }
 }
@@ -82,10 +84,10 @@ body {
 }
 
 ::-webkit-scrollbar-thumb {
-  background: hsl(var(--primary));
+  background: hsl(var(--border));
   border-radius: var(--radius);
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: hsl(var(--accent));
+  background: hsl(var(--primary));
 }

--- a/app/groups/page.tsx
+++ b/app/groups/page.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation'
 import { useState, useEffect } from 'react'
 import { Card, CardHeader, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { IconButton } from '@/components/ui/icon-button'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 import { supabase } from '@/lib/supabase'
@@ -182,14 +183,13 @@ export default function GroupsPage() {
               <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
                 <h2 className="text-xl font-semibold">{group.name}</h2>
                 {group.owner_id === user?.id && (
-                  <Button
-                    variant="ghost"
-                    size="icon"
-                    className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                  <IconButton
+                    aria-label={`Delete ${group.name}`}
+                    variant="destructive"
                     onClick={() => setGroupToDelete(group)}
                   >
                     <Trash2 className="h-4 w-4" />
-                  </Button>
+                  </IconButton>
                 )}
               </CardHeader>
               <CardContent>
@@ -220,7 +220,7 @@ export default function GroupsPage() {
           </DialogHeader>
           <form onSubmit={handleCreateGroup} className="space-y-4">
             <div className="space-y-2">
-              <label className="text-sm font-medium text-gray-500">
+              <label className="text-sm font-medium text-muted-foreground">
                 Group Name
               </label>
               <Input

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,10 +18,10 @@ export default function RootLayout({
   return (
     <html lang="en" className={GeistSans.className}>
       <head />
-      <body className="min-h-screen bg-[#F5E6D3]">
+      <body className="min-h-screen bg-background">
         <AuthProvider>
           <Navbar />
-          <main className="container mx-auto px-4 py-6">
+          <main className="container mx-auto px-4 py-5">
             {children}
           </main>
           <Toaster />

--- a/app/meals/create-meal-dialog.tsx
+++ b/app/meals/create-meal-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { IconButton } from '@/components/ui/icon-button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
@@ -11,6 +12,7 @@ import { toast } from 'sonner'
 import { useAuth } from '@/lib/contexts/AuthContext'
 import { cn } from '@/lib/utils'
 import { MEAL_CATEGORIES, MealCategory, getCategoryColor } from './meal-utils'
+import { X } from 'lucide-react'
 
 type Props = {
   open: boolean
@@ -124,7 +126,6 @@ export function CreateMealDialog({ open, onOpenChange, groupId, onMealCreated }:
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 required
-                className="bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
               />
             </div>
             
@@ -137,10 +138,10 @@ export function CreateMealDialog({ open, onOpenChange, groupId, onMealCreated }:
                     type="button"
                     onClick={() => setCategory(cat)}
                     className={cn(
-                      'px-3 py-1 rounded-full text-sm font-medium whitespace-nowrap',
+                      'px-3 py-1 rounded-full text-xs font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                       category === cat 
                         ? getCategoryColor(cat as MealCategory)
-                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                        : 'bg-surface-2 text-muted-foreground hover:bg-surface-2/80'
                     )}
                   >
                     {cat}
@@ -156,7 +157,6 @@ export function CreateMealDialog({ open, onOpenChange, groupId, onMealCreated }:
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
-                className="bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
               />
             </div>
 
@@ -168,7 +168,7 @@ export function CreateMealDialog({ open, onOpenChange, groupId, onMealCreated }:
                     placeholder="Search or add new ingredient"
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="w-full bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
+                    className="w-full"
                   />
                 </div>
                 <Button type="button" onClick={async () => {
@@ -208,7 +208,7 @@ export function CreateMealDialog({ open, onOpenChange, groupId, onMealCreated }:
 
               <div className="space-y-2">
                 {selectedIngredients.map((item, index) => (
-                  <div key={item.ingredient.id} className="flex flex-col sm:flex-row items-start sm:items-center gap-2 p-2 border rounded">
+                  <div key={item.ingredient.id} className="flex flex-col sm:flex-row items-start sm:items-center gap-2 rounded-[10px] border border-border/60 bg-card p-2">
                     <span className="font-medium flex-1">{item.ingredient.name}</span>
                     <div className="flex flex-wrap sm:flex-nowrap items-end gap-2 w-full sm:w-auto">
                       <div className="w-20">
@@ -224,7 +224,7 @@ export function CreateMealDialog({ open, onOpenChange, groupId, onMealCreated }:
                             newIngredients[index].quantity = e.target.value === '' ? 0 : parseFloat(e.target.value)
                             setSelectedIngredients(newIngredients)
                           }}
-                          className="w-full bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
+                          className="w-full"
                           min="0"
                           step="0.1"
                         />
@@ -241,7 +241,7 @@ export function CreateMealDialog({ open, onOpenChange, groupId, onMealCreated }:
                             newIngredients[index].unit = e.target.value
                             setSelectedIngredients(newIngredients)
                           }}
-                          className="h-10 w-full rounded-md border border-[#98C1B2]/30 bg-white/50 px-3 text-sm focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
+                          className="h-10 w-full rounded-[10px] border border-input bg-card px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
                         >
                           <option value="unit">unit</option>
                           <option value="oz">oz</option>
@@ -254,19 +254,17 @@ export function CreateMealDialog({ open, onOpenChange, groupId, onMealCreated }:
                           <option value="cup">cups</option>
                         </select>
                       </div>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
+                      <IconButton
+                        aria-label={`Remove ${item.ingredient.name}`}
+                        variant="destructive"
                         onClick={() => {
                           setSelectedIngredients(
                             selectedIngredients.filter((_, i) => i !== index)
                           )
                         }}
-                        className="text-destructive hover:text-destructive/90"
                       >
-                        x
-                      </Button>
+                        <X className="h-4 w-4" />
+                      </IconButton>
                     </div>
                   </div>
                 ))}

--- a/app/meals/edit-meal-dialog.tsx
+++ b/app/meals/edit-meal-dialog.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
+import { IconButton } from '@/components/ui/icon-button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Textarea } from '@/components/ui/textarea'
@@ -10,6 +11,7 @@ import { supabase } from '@/lib/supabase'
 import { toast } from 'sonner'
 import { cn } from '@/lib/utils'
 import { MEAL_CATEGORIES, MealCategory, getCategoryColor } from './meal-utils'
+import { X } from 'lucide-react'
 
 type Meal = {
   id: string
@@ -247,7 +249,6 @@ export function EditMealDialog({ open, onOpenChange, meal, onMealUpdated }: Prop
                 value={name}
                 onChange={(e) => setName(e.target.value)}
                 required
-                className="bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
               />
             </div>
             
@@ -260,10 +261,10 @@ export function EditMealDialog({ open, onOpenChange, meal, onMealUpdated }: Prop
                     type="button"
                     onClick={() => setCategory(cat)}
                     className={cn(
-                      'px-3 py-1 rounded-full text-sm font-medium whitespace-nowrap',
+                      'px-3 py-1 rounded-full text-xs font-medium whitespace-nowrap transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background',
                       category === cat 
                         ? getCategoryColor(cat as MealCategory)
-                        : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
+                        : 'bg-surface-2 text-muted-foreground hover:bg-surface-2/80'
                     )}
                   >
                     {cat}
@@ -279,7 +280,6 @@ export function EditMealDialog({ open, onOpenChange, meal, onMealUpdated }: Prop
                 value={description}
                 onChange={(e) => setDescription(e.target.value)}
                 rows={3}
-                className="bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
               />
             </div>
 
@@ -291,7 +291,7 @@ export function EditMealDialog({ open, onOpenChange, meal, onMealUpdated }: Prop
                     placeholder="Search or add new ingredient"
                     value={searchTerm}
                     onChange={(e) => setSearchTerm(e.target.value)}
-                    className="w-full bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
+                    className="w-full"
                   />
                 </div>
                 <Button type="button" onClick={handleAddIngredient} className="w-full sm:w-auto">
@@ -301,7 +301,7 @@ export function EditMealDialog({ open, onOpenChange, meal, onMealUpdated }: Prop
 
               <div className="space-y-2">
                 {selectedIngredients?.map((item, index) => (
-                  <div key={item?.ingredient?.id || index} className="flex flex-col sm:flex-row items-start sm:items-center gap-2 p-2 border rounded">
+                  <div key={item?.ingredient?.id || index} className="flex flex-col sm:flex-row items-start sm:items-center gap-2 rounded-[10px] border border-border/60 bg-card p-2">
                     <span className="font-medium flex-1">{item?.ingredient?.name}</span>
                     <div className="flex flex-wrap sm:flex-nowrap items-end gap-2 w-full sm:w-auto">
                       <div className="w-20">
@@ -317,7 +317,7 @@ export function EditMealDialog({ open, onOpenChange, meal, onMealUpdated }: Prop
                             newIngredients[index].quantity = e.target.value === '' ? 0 : parseFloat(e.target.value)
                             setSelectedIngredients(newIngredients)
                           }}
-                          className="w-full bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
+                          className="w-full"
                           min="0"
                           step="0.1"
                         />
@@ -334,7 +334,7 @@ export function EditMealDialog({ open, onOpenChange, meal, onMealUpdated }: Prop
                             newIngredients[index].unit = e.target.value
                             setSelectedIngredients(newIngredients)
                           }}
-                          className="h-10 w-full rounded-md border border-[#98C1B2]/30 bg-white/50 px-3 text-sm focus:border-[#98C1B2] focus:ring-[#98C1B2]/20"
+                          className="h-10 w-full rounded-[10px] border border-input bg-card px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
                         >
                           <option value="unit">unit</option>
                           <option value="oz">oz</option>
@@ -347,19 +347,17 @@ export function EditMealDialog({ open, onOpenChange, meal, onMealUpdated }: Prop
                           <option value="cup">cups</option>
                         </select>
                       </div>
-                      <Button
-                        type="button"
-                        variant="ghost"
-                        size="icon"
+                      <IconButton
+                        aria-label={`Remove ${item?.ingredient?.name}`}
+                        variant="destructive"
                         onClick={() => {
                           setSelectedIngredients(
                             selectedIngredients.filter((_, i) => i !== index)
                           )
                         }}
-                        className="text-destructive hover:text-destructive/90"
                       >
-                        x
-                      </Button>
+                        <X className="h-4 w-4" />
+                      </IconButton>
                     </div>
                   </div>
                 ))}

--- a/app/meals/page.tsx
+++ b/app/meals/page.tsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '@/lib/contexts/AuthContext'
 import { Button } from '@/components/ui/button'
+import { IconButton } from '@/components/ui/icon-button'
+import { Chip } from '@/components/ui/chip'
 import { Card, CardHeader, CardContent } from '@/components/ui/card'
 import { toast } from 'sonner'
 import { supabase } from '@/lib/supabase'
@@ -18,7 +20,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { Trash2, Pencil } from 'lucide-react'
+import { Trash2, Pencil, Search } from 'lucide-react'
 import { EditMealDialog } from './edit-meal-dialog'
 import { cn } from '@/lib/utils'
 import { MEAL_CATEGORIES, MealCategory, getCategoryColor } from './meal-utils'
@@ -154,14 +156,17 @@ export default function MealsPage() {
   })
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
-        <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Meal Library</h1>
-        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-4">
+    <div className="space-y-5">
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">Meal Library</h1>
+          <p className="text-sm text-muted-foreground">Browse and manage meals for your household.</p>
+        </div>
+        <div className="flex flex-col sm:flex-row items-stretch sm:items-center gap-3">
           <select
             value={selectedGroupId}
             onChange={(e) => setSelectedGroupId(e.target.value)}
-            className="h-10 w-full sm:w-[200px] rounded-md border border-input bg-background px-3 text-sm"
+            className="h-10 w-full sm:w-[220px] rounded-[10px] border border-input bg-card px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background"
           >
             <option value="">Select a group</option>
             {userGroups.map((group) => (
@@ -177,21 +182,24 @@ export default function MealsPage() {
       </div>
 
       <Card>
-        <CardHeader>
-          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
-            <h2 className="text-xl font-semibold">Your Meals</h2>
+        <CardHeader className="pb-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <h2 className="text-lg font-semibold">Your Meals</h2>
             <div className="flex w-full flex-col gap-3 sm:w-auto sm:flex-row sm:items-center">
-              <Input
-                type="search"
-                placeholder="Search meals..."
-                value={searchTerm}
-                onChange={(e) => setSearchTerm(e.target.value)}
-                className="w-full bg-white/50 border-[#98C1B2]/30 focus:border-[#98C1B2] focus:ring-[#98C1B2]/20 sm:w-64"
-              />
+              <div className="relative w-full sm:w-72">
+                <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                <Input
+                  type="search"
+                  placeholder="Search meals..."
+                  value={searchTerm}
+                  onChange={(e) => setSearchTerm(e.target.value)}
+                  className="w-full pl-9"
+                />
+              </div>
               <select
                 value={selectedCategory}
                 onChange={(event) => setSelectedCategory(event.target.value)}
-                className="h-10 w-full rounded-md border border-input bg-background px-3 text-sm sm:w-48"
+                className="h-10 w-full rounded-[10px] border border-input bg-card px-3 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background sm:w-48"
               >
                 <option value="">All categories</option>
                 {Object.values(MEAL_CATEGORIES).map((category) => (
@@ -203,61 +211,90 @@ export default function MealsPage() {
             </div>
           </div>
         </CardHeader>
-        <CardContent>
+        <CardContent className="space-y-3">
           {loading ? (
-            <p className="text-muted-foreground">Loading meals...</p>
+            <div className="space-y-3">
+              {Array.from({ length: 4 }).map((_, index) => (
+                <div
+                  key={index}
+                  className="rounded-xl border border-border/60 bg-card p-3 shadow-sm"
+                >
+                  <div className="flex items-center justify-between gap-4">
+                    <div className="space-y-2 flex-1">
+                      <div className="h-4 w-40 rounded-full bg-surface-2 animate-pulse" />
+                      <div className="h-3 w-64 rounded-full bg-surface-2 animate-pulse" />
+                    </div>
+                    <div className="h-6 w-16 rounded-full bg-surface-2 animate-pulse" />
+                  </div>
+                </div>
+              ))}
+            </div>
           ) : filteredMeals.length === 0 && selectedGroupId ? (
-            <p className="text-muted-foreground">
-              {searchTerm && selectedCategory ? (
-                <>
-                  No meals found matching &quot;{searchTerm}&quot; in {selectedCategory}
-                </>
-              ) : searchTerm ? (
-                <>No meals found matching &quot;{searchTerm}&quot;</>
-              ) : selectedCategory ? (
-                <>No meals found in {selectedCategory}</>
-              ) : (
-                'No meals have been created for this group yet.'
+            <div className="rounded-xl border border-border/60 bg-surface-2/70 p-6 text-center shadow-sm">
+              <p className="text-sm text-muted-foreground">
+                {searchTerm && selectedCategory ? (
+                  <>
+                    No meals found matching &quot;{searchTerm}&quot; in {selectedCategory}.
+                  </>
+                ) : searchTerm ? (
+                  <>No meals found matching &quot;{searchTerm}&quot;.</>
+                ) : selectedCategory ? (
+                  <>No meals found in {selectedCategory}.</>
+                ) : (
+                  'No meals have been created for this group yet.'
+                )}
+              </p>
+              {!searchTerm && !selectedCategory && (
+                <Button
+                  onClick={() => setShowCreateDialog(true)}
+                  className="mt-4"
+                >
+                  Create Meal
+                </Button>
               )}
-            </p>
+            </div>
           ) : !selectedGroupId ? (
-            <p className="text-muted-foreground">Select a group to view meals</p>
+            <div className="rounded-xl border border-border/60 bg-surface-2/70 p-6 text-center text-sm text-muted-foreground shadow-sm">
+              Select a group to view meals.
+            </div>
           ) : (
-            <div className="space-y-4">
+            <div className="space-y-2">
               {filteredMeals.map((meal) => (
                 <div
                   key={meal.id}
-                  className="flex flex-col sm:flex-row items-start sm:items-center justify-between p-4 border rounded-lg gap-4"
+                  className="group rounded-xl border border-border/60 bg-card p-3 shadow-sm transition-colors hover:bg-surface-2/60 hover:shadow-md focus-within:shadow-md"
                 >
-                  <div className="w-full sm:w-auto">
-                    <h3 className="font-medium">{meal.name}</h3>
-                    <p className="text-sm text-muted-foreground">{meal.description}</p>
-                    {meal.category && (
-                      <span className={cn(
-                        'inline-flex items-center rounded-full px-2 py-1 text-xs font-medium mt-2 sm:mt-1',
-                        getCategoryColor(meal.category as MealCategory)
-                      )}>
-                        {meal.category}
-                      </span>
-                    )}
-                  </div>
-                  <div className="flex items-center gap-2 w-full sm:w-auto justify-end">
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setMealToEdit(meal)}
-                      className="text-muted-foreground hover:text-foreground"
-                    >
-                      <Pencil className="h-4 w-4" />
-                    </Button>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      onClick={() => setMealToDelete(meal)}
-                      className="text-destructive hover:text-destructive/90"
-                    >
-                      <Trash2 className="h-4 w-4" />
-                    </Button>
+                  <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+                    <div className="space-y-1">
+                      <h3 className="text-base font-medium">{meal.name}</h3>
+                      {meal.description && (
+                        <p className="text-sm text-muted-foreground sm:max-w-md truncate">
+                          {meal.description}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex w-full flex-wrap items-center justify-between gap-2 sm:w-auto sm:justify-end">
+                      {meal.category && (
+                        <Chip className={cn("text-xs", getCategoryColor(meal.category as MealCategory))}>
+                          {meal.category}
+                        </Chip>
+                      )}
+                      <div className="flex items-center gap-1 opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
+                        <IconButton
+                          aria-label={`Edit ${meal.name}`}
+                          onClick={() => setMealToEdit(meal)}
+                        >
+                          <Pencil className="h-4 w-4" />
+                        </IconButton>
+                        <IconButton
+                          aria-label={`Delete ${meal.name}`}
+                          variant="destructive"
+                          onClick={() => setMealToDelete(meal)}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                        </IconButton>
+                      </div>
+                    </div>
                   </div>
                 </div>
               ))}

--- a/components/ui/alert-dialog.tsx
+++ b/components/ui/alert-dialog.tsx
@@ -36,7 +36,7 @@ const AlertDialogContent = React.forwardRef<
     <AlertDialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border/70 bg-background p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-xl",
         className
       )}
       {...props}

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -5,26 +5,26 @@ import { cva, type VariantProps } from "class-variance-authority"
 import { cn } from "@/lib/utils"
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-[10px] text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
   {
     variants: {
       variant: {
         default:
-          "bg-primary text-primary-foreground shadow hover:bg-primary/90",
+          "bg-primary text-primary-foreground shadow-sm hover:bg-primary/90 hover:shadow-md",
         destructive:
-          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90",
+          "bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90 hover:shadow-md",
         outline:
-          "border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground",
+          "border border-border/70 bg-transparent shadow-sm hover:bg-surface-2 hover:text-foreground",
         secondary:
           "bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80",
-        ghost: "hover:bg-accent hover:text-accent-foreground",
+        ghost: "hover:bg-surface-2 hover:text-foreground",
         link: "text-primary underline-offset-4 hover:underline",
       },
       size: {
-        default: "h-9 px-4 py-2",
-        sm: "h-8 rounded-md px-3 text-xs",
-        lg: "h-10 rounded-md px-8",
-        icon: "h-9 w-9",
+        default: "h-10 px-4 py-2",
+        sm: "h-8 rounded-[10px] px-3 text-xs",
+        lg: "h-11 rounded-[10px] px-8",
+        icon: "h-9 w-9 rounded-full",
       },
     },
     defaultVariants: {

--- a/components/ui/card.tsx
+++ b/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow",
+      "rounded-xl border border-border/60 bg-card text-card-foreground shadow-sm transition-shadow hover:shadow-md",
       className
     )}
     {...props}
@@ -23,7 +23,7 @@ const CardHeader = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex flex-col space-y-1.5 p-6", className)}
+    className={cn("flex flex-col space-y-1.5 p-5", className)}
     {...props}
   />
 ))
@@ -57,7 +57,7 @@ const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...props }, ref) => (
-  <div ref={ref} className={cn("p-6 pt-0", className)} {...props} />
+  <div ref={ref} className={cn("p-5 pt-0", className)} {...props} />
 ))
 CardContent.displayName = "CardContent"
 
@@ -67,7 +67,7 @@ const CardFooter = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn("flex items-center p-6 pt-0", className)}
+    className={cn("flex items-center p-5 pt-0", className)}
     {...props}
   />
 ))

--- a/components/ui/chip.tsx
+++ b/components/ui/chip.tsx
@@ -1,0 +1,21 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface ChipProps extends React.HTMLAttributes<HTMLSpanElement> {}
+
+const Chip = React.forwardRef<HTMLSpanElement, ChipProps>(
+  ({ className, ...props }, ref) => (
+    <span
+      ref={ref}
+      className={cn(
+        "inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Chip.displayName = "Chip"
+
+export { Chip }

--- a/components/ui/chip.tsx
+++ b/components/ui/chip.tsx
@@ -2,7 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface ChipProps extends React.HTMLAttributes<HTMLSpanElement> {}
+export type ChipProps = React.HTMLAttributes<HTMLSpanElement>
 
 const Chip = React.forwardRef<HTMLSpanElement, ChipProps>(
   ({ className, ...props }, ref) => (

--- a/components/ui/dialog.tsx
+++ b/components/ui/dialog.tsx
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border border-border/70 bg-background p-6 shadow-2xl duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-xl",
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-full opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-surface-2 data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      "flex cursor-default gap-2 select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-surface-2 data-[state=open]:bg-surface-2 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -47,7 +47,7 @@ const DropdownMenuSubContent = React.forwardRef<
   <DropdownMenuPrimitive.SubContent
     ref={ref}
     className={cn(
-      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-border/70 bg-popover p-1 text-popover-foreground shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
       className
     )}
     {...props}
@@ -64,11 +64,11 @@ const DropdownMenuContent = React.forwardRef<
     <DropdownMenuPrimitive.Content
       ref={ref}
       sideOffset={sideOffset}
-      className={cn(
-        "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md",
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
-        className
-      )}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-xl border border-border/70 bg-popover p-1 text-popover-foreground shadow-xl",
+      "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
       {...props}
     />
   </DropdownMenuPrimitive.Portal>
@@ -84,7 +84,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-surface-2 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
       inset && "pl-8",
       className
     )}
@@ -100,7 +100,7 @@ const DropdownMenuCheckboxItem = React.forwardRef<
   <DropdownMenuPrimitive.CheckboxItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-surface-2 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     checked={checked}
@@ -124,7 +124,7 @@ const DropdownMenuRadioItem = React.forwardRef<
   <DropdownMenuPrimitive.RadioItem
     ref={ref}
     className={cn(
-      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-surface-2 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/components/ui/icon-button.tsx
+++ b/components/ui/icon-button.tsx
@@ -1,0 +1,38 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const iconButtonVariants = cva(
+  "inline-flex h-9 w-9 items-center justify-center rounded-full border border-transparent text-sm text-foreground transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:pointer-events-none disabled:opacity-50",
+  {
+    variants: {
+      variant: {
+        ghost: "hover:bg-surface-2",
+        destructive: "text-destructive hover:bg-destructive/10",
+        subtle: "bg-surface-2 text-foreground hover:bg-surface-2/80",
+      },
+    },
+    defaultVariants: {
+      variant: "ghost",
+    },
+  }
+)
+
+export interface IconButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof iconButtonVariants> {}
+
+const IconButton = React.forwardRef<HTMLButtonElement, IconButtonProps>(
+  ({ className, variant, type = "button", ...props }, ref) => (
+    <button
+      ref={ref}
+      type={type}
+      className={cn(iconButtonVariants({ variant }), className)}
+      {...props}
+    />
+  )
+)
+IconButton.displayName = "IconButton"
+
+export { IconButton }

--- a/components/ui/input.tsx
+++ b/components/ui/input.tsx
@@ -8,7 +8,7 @@ const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
       <input
         type={type}
         className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+          "flex h-10 w-full rounded-[10px] border border-input bg-card px-3 py-2 text-sm shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
           className
         )}
         ref={ref}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      "flex h-9 w-full items-center justify-between whitespace-nowrap rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
+      "flex h-10 w-full items-center justify-between whitespace-nowrap rounded-[10px] border border-input bg-card px-3 py-2 text-sm shadow-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 focus:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1",
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+        "relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-xl border border-border/70 bg-popover text-popover-foreground shadow-xl data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className
@@ -118,7 +118,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      "relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-surface-2 focus:text-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
       className
     )}
     {...props}

--- a/components/ui/textarea.tsx
+++ b/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<
   return (
     <textarea
       className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        "flex min-h-[80px] w-full rounded-[10px] border border-input bg-card px-3 py-2 text-sm shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50",
         className
       )}
       ref={ref}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -24,6 +24,7 @@ const config = {
   			ring: "hsl(var(--ring))",
   			background: "hsl(var(--background))",
   			foreground: "hsl(var(--foreground))",
+  			"surface-2": "hsl(var(--surface-2))",
   			primary: {
   				DEFAULT: "hsl(var(--primary))",
   				foreground: "hsl(var(--primary-foreground))",


### PR DESCRIPTION
### Motivation
- Move the app from a warm-beige flat look to a layered neutral system with distinct surfaces, reduced border weight, and subtle elevation for better visual hierarchy.
- Standardize radii, spacing, focus rings, and icon button treatments for consistent accessibility and hit targets.
- Improve calendar and meal library layouts to be denser, more keyboard-friendly, and visually scannable while preserving existing data and behavior.

### Description
- Introduced global theme tokens and surface layering in `app/globals.css` and added `surface-2` to `tailwind.config.ts` to support layered neutral backgrounds and consistent border/ring tokens. 
- Added new UI primitives `IconButton` and `Chip` (`components/ui/icon-button.tsx`, `components/ui/chip.tsx`) and updated shared primitives (`button`, `card`, `input`, `textarea`, `select`, `dialog`, `dropdown-menu`) to use consistent radius, lighter borders, subtle shadows, and stronger focus rings. 
- Updated layout and navigation to use the new background and spacing (`app/layout.tsx`, `app/components/navbar.tsx`).
- Revamped Calendar UI: toolbar, month navigation, day cells, hover/add affordances, keyboard/ARIA accessibility, chip rendering for meals, responsive cell behavior and visual distinctions for outside-month days (`app/calendar/page.tsx`, `app/calendar/add-meal-modal.tsx`).
- Refreshed Meal Library UI: compact toolbar (search + filters), denser list rows, hover-revealed icon actions, refined category chips, improved loading skeletons and empty-state card (`app/meals/page.tsx`, `app/meals/create-meal-dialog.tsx`, `app/meals/edit-meal-dialog.tsx`).
- Minor updates to groups and dialogs to align with the new surface system (`app/groups/page.tsx`, `components/ui/alert-dialog.tsx`, `components/ui/dialog.tsx`).

### Testing
- Started the local Next.js dev server via `npm run dev` and observed it start successfully (Next.js dev server ready). (succeeded)
- Automated UI smoke run using Playwright navigated to `/auth`, signed in with provided credentials, then captured full-page screenshots of `/calendar` and `/meals` for visual verification; artifacts were produced (screenshots captured). (succeeded)
- No automated unit tests were added or run; changes are visual/UI-focused and preserve existing routes/data queries and business logic. (n/a)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ecb7ede10832e87a0d6a526b3d7df)