### PR TITLE
Fix sign-out: implement handler in AuthContext and redirect to /auth

### DIFF
--- a/lib/contexts/AuthContext.tsx
+++ b/lib/contexts/AuthContext.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import React, { createContext, useContext, useEffect, useState } from 'react'
+import { useRouter } from 'next/navigation'
 import { User, Session } from '@supabase/supabase-js'
 import { supabase } from '@/lib/supabase'
 
@@ -17,6 +18,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(null)
   const [session, setSession] = useState<Session | null>(null)
   const [loading, setLoading] = useState(true)
+  const router = useRouter()
 
   useEffect(() => {
     // Check active sessions
@@ -36,8 +38,16 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     return () => subscription.unsubscribe()
   }, [])
 
+  const signOut = async () => {
+    await supabase.auth.signOut()
+    setSession(null)
+    setUser(null)
+    router.push('/auth')
+    router.refresh()
+  }
+
   return (
-    <AuthContext.Provider value={{ user, session, loading, signOut: async () => {} }}>
+    <AuthContext.Provider value={{ user, session, loading, signOut }}>
       {children}
     </AuthContext.Provider>
   )


### PR DESCRIPTION
### Motivation
- Implement the `signOut` handler in `lib/contexts/AuthContext.tsx` so the Navbar's `Sign Out` action actually signs the user out and navigates to `/auth`.

### Description
- Add `useRouter` from `next/navigation`, implement `signOut` to call `supabase.auth.signOut()`, clear `user` and `session` state, then call `router.push('/auth')` and `router.refresh()`, and expose `signOut` via the `AuthContext` provider.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ed1c9c160832e95fa41d93fbb0d59)