### PR TITLE
Improve calendar range selection visibility

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -485,6 +485,9 @@ export default function CalendarPage() {
                 const isOutsideMonth = !isSameMonth(day, currentDate)
                 const isToday = isSameDay(day, new Date())
                 const isSingleSelection = !!dateRange.start && (!dateRange.end || (dateRange.end && isSameDay(dateRange.start, dateRange.end)))
+                const isRangeStartDay = isRangeStart(day)
+                const isRangeEndDay = isRangeEnd(day)
+                const isInRange = isDateInRange(day)
                 const mealsForDay = meal ? [meal] : []
 
                 return (
@@ -505,10 +508,10 @@ export default function CalendarPage() {
                       "group min-h-[92px] sm:min-h-[108px] border-b border-r border-border/60 p-2.5 bg-card relative cursor-pointer transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                       isOutsideMonth && "text-muted-foreground/60",
                       meal && "bg-surface-2/50",
-                      isDateInRange(day) && "bg-primary/5",
-                      isSingleSelection && dateRange.start && isSameDay(day, dateRange.start) && "ring-2 ring-primary/40",
-                      dateRange.end && isRangeStart(day) && "ring-2 ring-primary/40",
-                      dateRange.end && isRangeEnd(day) && "ring-2 ring-primary/40",
+                      isInRange && "bg-primary/15 ring-1 ring-inset ring-primary/30",
+                      isSingleSelection && dateRange.start && isSameDay(day, dateRange.start) && "bg-primary/20 ring-2 ring-inset ring-primary/70",
+                      dateRange.end && isRangeStartDay && "bg-primary/20 ring-2 ring-inset ring-primary/70",
+                      dateRange.end && isRangeEndDay && "bg-primary/20 ring-2 ring-inset ring-primary/70",
                       !meal && "hover:bg-surface-2/60",
                       meal && "hover:bg-surface-2/70"
                     )}
@@ -603,6 +606,10 @@ export default function CalendarPage() {
               {mobileDays.map((day) => {
                 const dateStr = format(day, "yyyy-MM-dd")
                 const meal = calendarMeals[dateStr]
+                const isRangeStartDay = isRangeStart(day)
+                const isRangeEndDay = isRangeEnd(day)
+                const isInRange = isDateInRange(day)
+                const isSingleSelection = !!dateRange.start && (!dateRange.end || (dateRange.end && isSameDay(dateRange.start, dateRange.end)))
 
                 return (
                   <div
@@ -622,7 +629,10 @@ export default function CalendarPage() {
                       "p-3 bg-card rounded-xl border border-border/60 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background",
                       "hover:bg-surface-2/60",
                       meal && "bg-surface-2/50",
-                      isDateInRange(day) && "ring-2 ring-primary/40 z-10"
+                      isInRange && "bg-primary/15 ring-1 ring-inset ring-primary/30",
+                      isSingleSelection && dateRange.start && isSameDay(day, dateRange.start) && "bg-primary/20 ring-2 ring-inset ring-primary/70",
+                      dateRange.end && isRangeStartDay && "bg-primary/20 ring-2 ring-inset ring-primary/70",
+                      dateRange.end && isRangeEndDay && "bg-primary/20 ring-2 ring-inset ring-primary/70"
                     )}
                   >
                     <div className="flex justify-between items-start gap-2">


### PR DESCRIPTION
### Motivation
- Make it visually obvious when a user selects a range of days on the meal calendar so generating groceries is clearer. 
- Fix inconsistent borders and selection styling around the first and last days of a selected range so start/end days appear distinct and consistent. 

### Description
- Updated `app/calendar/page.tsx` to compute `isInRange`, `isRangeStartDay`, and `isRangeEndDay` for each day and use those flags when rendering the cell. 
- Replaced the subtle `bg-primary/5` and intermittent rings with stronger inset rings and background fills (`bg-primary/15`, `bg-primary/20`, `ring-1 ring-inset ring-primary/30`, and `ring-2 ring-inset ring-primary/70`) for in-range, single-selection, and start/end states to improve contrast. 
- Applied the same visual treatment to the mobile (`sm:hidden`) day cards so desktop and mobile selections are consistent. 

### Testing
- Launched the app dev server with `npm run dev` and confirmed Next compiled the pages and the auth page rendered successfully. 
- Attempted an automated Playwright flow to sign in and capture a screenshot of a selected date range, but the script could not reach `/calendar` due to auth navigation, so the visual result could not be captured automatically. 
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ed63a0230832eba9a42ab3675db7c)