### PR TITLE
Fix add-meal modal search input focus clipping

### DIFF
--- a/app/calendar/add-meal-modal.tsx
+++ b/app/calendar/add-meal-modal.tsx
@@ -99,7 +99,7 @@ export function AddMealModal({ open, onOpenChange, groupId, date, onMealAdded }:
           <DialogTitle>Add Meal to {date.toLocaleDateString()}</DialogTitle>
         </DialogHeader>
 
-        <div className="flex-1 overflow-y-auto pr-2">
+        <div className="flex-1 overflow-y-auto pr-2 pt-1">
           <form id="add-meal-form" onSubmit={handleSubmit} className="space-y-4">
             <div className="grid gap-3 sm:grid-cols-[minmax(0,2fr)_minmax(0,1fr)] sm:items-center">
               <Input


### PR DESCRIPTION
### Motivation
- Prevent the search input's focus ring from being clipped at the top of the Add Meal modal when the input is focused.

### Description
- Add a small top padding (`pt-1`) to the modal scroll container in `app/calendar/add-meal-modal.tsx` so the input focus outline is fully visible.

### Testing
- Started the dev server with `npm run dev` successfully, and attempted an automated Playwright script to open the modal and capture a screenshot but the Playwright run timed out / failed to locate the modal after login (automated screenshot attempt failed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f8192e340832e8a1cf0730153e4e2)