### PR TITLE
Add animated loading overlay to meal calendar

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -49,6 +49,7 @@ export default function CalendarPage() {
   }>({ start: null, end: null })
   const [isAuthChecking, setIsAuthChecking] = useState(true)
   const [isMonthLoading, setIsMonthLoading] = useState(false)
+  const [hasLoadedMeals, setHasLoadedMeals] = useState(false)
   const [mobileWeekStart, setMobileWeekStart] = useState(startOfWeek(new Date()))
   const [randomizingDate, setRandomizingDate] = useState<string | null>(null)
 
@@ -124,6 +125,7 @@ export default function CalendarPage() {
     if (selectedGroupId) {
       const fetchMeals = async () => {
         if (!mounted) return
+        setHasLoadedMeals(false)
         setIsMonthLoading(true)
         
         try {
@@ -154,11 +156,15 @@ export default function CalendarPage() {
         } finally {
           if (mounted) {
             setIsMonthLoading(false)
+            setHasLoadedMeals(true)
           }
         }
       }
 
       fetchMeals()
+    } else {
+      setHasLoadedMeals(true)
+      setIsMonthLoading(false)
     }
 
     return () => {
@@ -407,6 +413,8 @@ export default function CalendarPage() {
     )
   }
 
+  const showLoadingState = isMonthLoading || !hasLoadedMeals
+
   const desktopLoadingOverlay = (
     <div className="absolute inset-0 z-10 grid grid-cols-7 bg-background/60 backdrop-blur-sm">
       {days.map((day) => (
@@ -525,7 +533,7 @@ export default function CalendarPage() {
 
           <div className="hidden sm:block">
             <div className="grid grid-cols-7 border border-border/60 rounded-lg overflow-hidden relative">
-              {isMonthLoading && desktopLoadingOverlay}
+              {showLoadingState && desktopLoadingOverlay}
               {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((dayName) => (
                 <div
                   key={dayName}
@@ -673,7 +681,7 @@ export default function CalendarPage() {
 
           <div className="sm:hidden">
             <div className="flex flex-col gap-2 relative">
-              {isMonthLoading && mobileLoadingOverlay}
+              {showLoadingState && mobileLoadingOverlay}
               {mobileDays.map((day) => {
                 const dateStr = format(day, "yyyy-MM-dd")
                 const meal = calendarMeals[dateStr]

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { IconButton } from "@/components/ui/icon-button"
 import { Chip } from "@/components/ui/chip"
-import { ChevronLeft, ChevronRight, Dice5, Loader2, Moon, MoonStar, Plus, Trash2 } from "lucide-react"
+import { ChevronLeft, ChevronRight, Dice5, Moon, MoonStar, Plus, Trash2 } from "lucide-react"
 import {
   format,
   addMonths,
@@ -407,25 +407,43 @@ export default function CalendarPage() {
     )
   }
 
-  const loadingOverlay = (
-    <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/70 backdrop-blur-sm">
-      <div className="flex flex-col items-center gap-3 rounded-xl border border-border/60 bg-card/90 px-5 py-4 shadow-lg">
-        <div className="flex items-center gap-3">
-          <span className="relative flex h-10 w-10 items-center justify-center">
-            <span className="absolute inset-0 rounded-full bg-primary/20 animate-ping" />
-            <Loader2 className="h-5 w-5 animate-spin text-primary" aria-hidden="true" />
-          </span>
-          <div>
-            <p className="text-sm font-semibold text-foreground">Loading calendar</p>
-            <p className="text-xs text-muted-foreground">Fetching meals for this range…</p>
+  const desktopLoadingOverlay = (
+    <div className="absolute inset-0 z-10 grid grid-cols-7 bg-background/60 backdrop-blur-sm">
+      {days.map((day) => (
+        <div
+          key={`loading-${day.toISOString()}`}
+          className="min-h-[92px] sm:min-h-[108px] border-b border-r border-border/60 p-2.5"
+        >
+          <div className="flex items-center justify-between">
+            <div className="h-3 w-6 rounded-full bg-surface-2 animate-pulse" />
+            <div className="h-4 w-4 rounded-full bg-surface-2 animate-pulse" />
+          </div>
+          <div className="mt-3 space-y-2">
+            <div className="h-3 w-16 rounded-full bg-surface-2 animate-pulse" />
+            <div className="h-3 w-24 rounded-full bg-surface-2 animate-pulse" />
           </div>
         </div>
-        <div className="flex w-full gap-2">
-          <div className="h-2 flex-1 rounded-full bg-surface-2 animate-pulse" />
-          <div className="h-2 flex-1 rounded-full bg-surface-2 animate-pulse [animation-delay:150ms]" />
-          <div className="h-2 flex-1 rounded-full bg-surface-2 animate-pulse [animation-delay:300ms]" />
+      ))}
+    </div>
+  )
+
+  const mobileLoadingOverlay = (
+    <div className="absolute inset-0 z-10 flex flex-col gap-2 bg-background/60 backdrop-blur-sm p-3">
+      {mobileDays.map((day) => (
+        <div
+          key={`mobile-loading-${day.toISOString()}`}
+          className="rounded-xl border border-border/60 bg-card/70 p-3 shadow-sm"
+        >
+          <div className="flex items-center justify-between">
+            <div className="h-3 w-20 rounded-full bg-surface-2 animate-pulse" />
+            <div className="h-4 w-4 rounded-full bg-surface-2 animate-pulse" />
+          </div>
+          <div className="mt-3 space-y-2">
+            <div className="h-3 w-32 rounded-full bg-surface-2 animate-pulse" />
+            <div className="h-3 w-24 rounded-full bg-surface-2 animate-pulse" />
+          </div>
         </div>
-      </div>
+      ))}
     </div>
   )
 
@@ -507,7 +525,7 @@ export default function CalendarPage() {
 
           <div className="hidden sm:block">
             <div className="grid grid-cols-7 border border-border/60 rounded-lg overflow-hidden relative">
-              {isMonthLoading && loadingOverlay}
+              {isMonthLoading && desktopLoadingOverlay}
               {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((dayName) => (
                 <div
                   key={dayName}
@@ -655,7 +673,7 @@ export default function CalendarPage() {
 
           <div className="sm:hidden">
             <div className="flex flex-col gap-2 relative">
-              {isMonthLoading && loadingOverlay}
+              {isMonthLoading && mobileLoadingOverlay}
               {mobileDays.map((day) => {
                 const dateStr = format(day, "yyyy-MM-dd")
                 const meal = calendarMeals[dateStr]

--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from "next/navigation"
 import { Button } from "@/components/ui/button"
 import { IconButton } from "@/components/ui/icon-button"
 import { Chip } from "@/components/ui/chip"
-import { ChevronLeft, ChevronRight, Dice5, Moon, MoonStar, Plus, Trash2 } from "lucide-react"
+import { ChevronLeft, ChevronRight, Dice5, Loader2, Moon, MoonStar, Plus, Trash2 } from "lucide-react"
 import {
   format,
   addMonths,
@@ -407,6 +407,28 @@ export default function CalendarPage() {
     )
   }
 
+  const loadingOverlay = (
+    <div className="absolute inset-0 z-10 flex items-center justify-center bg-background/70 backdrop-blur-sm">
+      <div className="flex flex-col items-center gap-3 rounded-xl border border-border/60 bg-card/90 px-5 py-4 shadow-lg">
+        <div className="flex items-center gap-3">
+          <span className="relative flex h-10 w-10 items-center justify-center">
+            <span className="absolute inset-0 rounded-full bg-primary/20 animate-ping" />
+            <Loader2 className="h-5 w-5 animate-spin text-primary" aria-hidden="true" />
+          </span>
+          <div>
+            <p className="text-sm font-semibold text-foreground">Loading calendar</p>
+            <p className="text-xs text-muted-foreground">Fetching meals for this range…</p>
+          </div>
+        </div>
+        <div className="flex w-full gap-2">
+          <div className="h-2 flex-1 rounded-full bg-surface-2 animate-pulse" />
+          <div className="h-2 flex-1 rounded-full bg-surface-2 animate-pulse [animation-delay:150ms]" />
+          <div className="h-2 flex-1 rounded-full bg-surface-2 animate-pulse [animation-delay:300ms]" />
+        </div>
+      </div>
+    </div>
+  )
+
   return (
     <div className="min-h-screen space-y-5">
       <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
@@ -485,9 +507,7 @@ export default function CalendarPage() {
 
           <div className="hidden sm:block">
             <div className="grid grid-cols-7 border border-border/60 rounded-lg overflow-hidden relative">
-              {isMonthLoading && (
-                <div className="absolute inset-0 bg-background/80 z-10 transition-opacity duration-200" />
-              )}
+              {isMonthLoading && loadingOverlay}
               {["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"].map((dayName) => (
                 <div
                   key={dayName}
@@ -635,9 +655,7 @@ export default function CalendarPage() {
 
           <div className="sm:hidden">
             <div className="flex flex-col gap-2 relative">
-              {isMonthLoading && (
-                <div className="absolute inset-0 bg-background/80 z-10 transition-opacity duration-200" />
-              )}
+              {isMonthLoading && loadingOverlay}
               {mobileDays.map((day) => {
                 const dateStr = format(day, "yyyy-MM-dd")
                 const meal = calendarMeals[dateStr]


### PR DESCRIPTION
### Motivation
- Reduce visual flicker when the calendar fetches meal data by showing a polished loading state while month/week data is being loaded.

### Description
- Add a centered loading overlay component (`loadingOverlay`) with a spinner, ping ring, title/subtitle, and animated pulse bars to `app/calendar/page.tsx` and import `Loader2` from `lucide-react`.
- Replace the previous simple translucent overlay shown during `isMonthLoading` with the new `loadingOverlay` for both the desktop grid and mobile list views.
- Use bracketed Tailwind utility syntax for staggered animation delays on the pulse bars for a smoother effect.

### Testing
- Started the dev server with `npm run dev` and confirmed the app compiled and served the pages successfully.
- Ran a Playwright smoke script that navigated to `/auth` (sign-in using `USERNAME`/`PASSWORD` if present), opened `/calendar`, clicked the next-month button to trigger the loading state, and captured a screenshot to `artifacts/calendar-loading.png`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698006ae81b4832e83d68bedbe9219b3)