### PR TITLE
Make grocery list button more prominent on calendar

### DIFF
--- a/app/calendar/page.tsx
+++ b/app/calendar/page.tsx
@@ -433,8 +433,9 @@ export default function CalendarPage() {
             <Button
               onClick={handleGenerateList}
               data-grocery-button
-              variant="secondary"
-              className="w-full sm:w-auto"
+              variant="default"
+              size="lg"
+              className="w-full sm:w-auto font-semibold shadow-md hover:shadow-lg"
             >
               Generate Grocery List
             </Button>


### PR DESCRIPTION
### Motivation
- Make the `Generate Grocery List` button more visually prominent so it’s easier to find on the calendar page.

### Description
- Update `app/calendar/page.tsx` to change the grocery button `variant` from `secondary` to `default`, set `size="lg"`, and add `font-semibold shadow-md hover:shadow-lg` for stronger emphasis.

### Testing
- Started the dev server with `npm run dev` and ran a Playwright smoke script that navigated to `/auth`, signed in, selected a date range, and produced `artifacts/calendar-grocery-button.png`, confirming the updated button rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698007a28c84832e8dc55c758eb1dfc6)