### PR TITLE
Prevent auth UI flicker during session hydration

### DIFF
--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { supabase } from '@/lib/supabase'
+import { useAuth } from '@/lib/contexts/AuthContext'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardHeader, CardContent } from '@/components/ui/card'
@@ -15,6 +16,7 @@ import authBgImage from '@/public/auth-bg.jpg'
 
 export default function AuthPage() {
   const router = useRouter()
+  const { user, loading: authLoading } = useAuth()
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [loading, setLoading] = useState(false)
@@ -36,6 +38,16 @@ export default function AuthPage() {
     }
     checkSession()
   }, [router])
+
+  useEffect(() => {
+    if (!authLoading && user) {
+      router.replace('/calendar')
+    }
+  }, [authLoading, router, user])
+
+  if (authLoading || user) {
+    return <div className="min-h-[calc(100vh-4rem)]" />
+  }
 
   console.log('Auth page rendered', new Date().toISOString())
 

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -14,7 +14,7 @@ import {
 import { Avatar, AvatarFallback } from "@/components/ui/avatar"
 
 export function Navbar() {
-  const { user, signOut } = useAuth()
+  const { user, signOut, loading } = useAuth()
   const pathname = usePathname()
 
   const navItems = [
@@ -35,7 +35,7 @@ export function Navbar() {
 
           {/* Desktop menu */}
           <div className="hidden sm:flex items-center gap-8">
-            {user && navItems.map(item => (
+            {!loading && user && navItems.map(item => (
               <Link
                 key={item.href}
                 href={item.href}
@@ -51,7 +51,9 @@ export function Navbar() {
             ))}
           </div>
 
-          {user ? (
+          {loading ? (
+            <div className="h-8 w-8 rounded-full bg-muted/60 animate-pulse" aria-hidden="true" />
+          ) : user ? (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <Button variant="ghost" className="relative h-8 w-8 rounded-full">


### PR DESCRIPTION
### Motivation
- The nav and auth pages briefly show unauthenticated UI on reload because client session state hydrates asynchronously, causing a visible flash of the Sign In controls.
- The change aims to prevent that race by delaying rendering of auth-sensitive UI until the client auth state is known.

### Description
- Use the auth loading state in `app/components/navbar.tsx` to hide navigation links during session hydration and render a small animated placeholder instead of the Sign In button or avatar dropdown.
- Short-circuit the auth route in `app/auth/page.tsx` by reading `useAuth()` and returning a minimal placeholder while `authLoading` is true or when a `user` is present, and add an effect to redirect authenticated users once hydration completes.
- Files modified: `app/components/navbar.tsx`, `app/auth/page.tsx`.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and the app compiled and served the `/auth` route successfully (GET `/auth` 200). (Succeeded.)
- Ran a Playwright script that loaded `http://127.0.0.1:3000/auth`, exercised sign-in UI, and produced a screenshot at `artifacts/authenticated-navbar.png` to verify the navbar no longer flashes the Sign In button while the session hydrates. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69800ac352f0832e824bf3311f74de70)