### PR TITLE
Add view-only meal modal in library

### DIFF
--- a/app/meals/page.tsx
+++ b/app/meals/page.tsx
@@ -20,8 +20,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog"
-import { Trash2, Pencil } from 'lucide-react'
+import { Eye, Trash2, Pencil } from 'lucide-react'
 import { EditMealDialog } from './edit-meal-dialog'
+import { ViewMealDialog } from './view-meal-dialog'
 import { cn } from '@/lib/utils'
 import { MEAL_CATEGORIES, MealCategory, WEEKNIGHT_FRIENDLY_LABEL, getCategoryColor, getWeeknightFriendlyColor, getWeeknightNotFriendlyColor } from './meal-utils'
 import { MealFilterRack, WeeknightFilterOption } from '@/components/meal-filter-rack'
@@ -51,6 +52,7 @@ export default function MealsPage() {
   const [mealToDelete, setMealToDelete] = useState<Meal | null>(null)
   const [isDeleting, setIsDeleting] = useState(false)
   const [mealToEdit, setMealToEdit] = useState<Meal | null>(null)
+  const [mealToView, setMealToView] = useState<Meal | null>(null)
   const [searchTerm, setSearchTerm] = useState('')
   const [selectedCategory, setSelectedCategory] = useState('all')
   const [weeknightFilter, setWeeknightFilter] = useState<'all' | 'friendly' | 'not-friendly'>('all')
@@ -268,18 +270,24 @@ export default function MealsPage() {
                         </p>
                       )}
                     </div>
-                  <div className="flex w-full flex-wrap items-center justify-between gap-2 sm:w-auto sm:justify-end">
-                    {meal.category && (
-                      <Chip className={cn("text-xs", getCategoryColor(meal.category as MealCategory))}>
-                        {meal.category}
-                      </Chip>
-                    )}
-                    {meal.weeknight_friendly && (
-                      <Chip className={cn("text-xs", getWeeknightFriendlyColor())}>
-                        {WEEKNIGHT_FRIENDLY_LABEL}
-                      </Chip>
-                    )}
-                    <div className="flex items-center gap-1 opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
+                    <div className="flex w-full flex-wrap items-center justify-between gap-2 sm:w-auto sm:justify-end">
+                      {meal.category && (
+                        <Chip className={cn("text-xs", getCategoryColor(meal.category as MealCategory))}>
+                          {meal.category}
+                        </Chip>
+                      )}
+                      {meal.weeknight_friendly && (
+                        <Chip className={cn("text-xs", getWeeknightFriendlyColor())}>
+                          {WEEKNIGHT_FRIENDLY_LABEL}
+                        </Chip>
+                      )}
+                      <div className="flex items-center gap-1 opacity-100 transition sm:opacity-0 sm:group-hover:opacity-100 sm:group-focus-within:opacity-100">
+                        <IconButton
+                          aria-label={`View ${meal.name}`}
+                          onClick={() => setMealToView(meal)}
+                        >
+                          <Eye className="h-4 w-4" />
+                        </IconButton>
                         <IconButton
                           aria-label={`Edit ${meal.name}`}
                           onClick={() => setMealToEdit(meal)}
@@ -315,6 +323,12 @@ export default function MealsPage() {
         onOpenChange={(open) => !open && setMealToEdit(null)}
         meal={mealToEdit}
         onMealUpdated={fetchMeals}
+      />
+
+      <ViewMealDialog
+        open={!!mealToView}
+        onOpenChange={(open) => !open && setMealToView(null)}
+        meal={mealToView}
       />
 
       <AlertDialog open={!!mealToDelete} onOpenChange={(open) => !open && setMealToDelete(null)}>

--- a/app/meals/view-meal-dialog.tsx
+++ b/app/meals/view-meal-dialog.tsx
@@ -1,0 +1,161 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import { Chip } from '@/components/ui/chip'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+import { supabase } from '@/lib/supabase'
+import {
+  MealCategory,
+  WEEKNIGHT_FRIENDLY_LABEL,
+  getCategoryColor,
+  getWeeknightFriendlyColor,
+  getWeeknightNotFriendlyColor,
+} from './meal-utils'
+
+type Meal = {
+  id: string
+  name: string
+  description: string
+  category: string
+  weeknight_friendly: boolean
+  group_id: string
+}
+
+type Ingredient = {
+  id: string
+  name: string
+}
+
+type MealIngredient = {
+  ingredient: Ingredient
+  quantity: number
+  unit: string
+}
+
+type Props = {
+  open: boolean
+  onOpenChange: (open: boolean) => void
+  meal: Meal | null
+}
+
+export function ViewMealDialog({ open, onOpenChange, meal }: Props) {
+  const [ingredients, setIngredients] = useState<MealIngredient[]>([])
+
+  useEffect(() => {
+    if (!meal) {
+      setIngredients([])
+      return
+    }
+
+    const fetchMealIngredients = async () => {
+      type DBIngredient = {
+        quantity: number
+        unit: string
+        ingredient: { id: string; name: string }
+      }
+
+      const { data } = await supabase
+        .from('meal_ingredients')
+        .select(`
+          quantity,
+          unit,
+          ingredient:ingredients(id, name)
+        `)
+        .eq('meal_id', meal.id)
+        .returns<DBIngredient[]>()
+
+      if (data) {
+        setIngredients(
+          data.map((item) => ({
+            ingredient: item.ingredient,
+            quantity: item.quantity,
+            unit: item.unit,
+          }))
+        )
+      }
+    }
+
+    fetchMealIngredients()
+  }, [meal])
+
+  const hasCategory = Boolean(meal?.category)
+  const hasDescription = Boolean(meal?.description)
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-h-[90vh] flex flex-col w-full max-w-2xl mx-auto">
+        <DialogHeader>
+          <DialogTitle>View Meal</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex-1 space-y-5 overflow-y-auto pr-2">
+          <div className="space-y-2">
+            <Label>Name</Label>
+            <p className="text-sm font-medium text-foreground">{meal?.name}</p>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Category</Label>
+            <div className="flex flex-wrap gap-2">
+              {hasCategory ? (
+                <Chip className={cn('text-xs', getCategoryColor(meal?.category as MealCategory))}>
+                  {meal?.category}
+                </Chip>
+              ) : (
+                <p className="text-sm text-muted-foreground">No category selected.</p>
+              )}
+              {meal?.weeknight_friendly ? (
+                <Chip className={cn('text-xs', getWeeknightFriendlyColor())}>
+                  {WEEKNIGHT_FRIENDLY_LABEL}
+                </Chip>
+              ) : (
+                <Chip className={cn('text-xs', getWeeknightNotFriendlyColor())}>
+                  Not weeknight friendly
+                </Chip>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label>Description</Label>
+            {hasDescription ? (
+              <p className="text-sm text-muted-foreground whitespace-pre-line">{meal?.description}</p>
+            ) : (
+              <p className="text-sm text-muted-foreground">No description provided.</p>
+            )}
+          </div>
+
+          <div className="space-y-3">
+            <Label>Ingredients</Label>
+            {ingredients.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No ingredients added yet.</p>
+            ) : (
+              <div className="space-y-2">
+                {ingredients.map((item) => (
+                  <div
+                    key={item.ingredient.id}
+                    className="flex items-center justify-between gap-3 rounded-[10px] border border-border/60 bg-card p-2 text-sm"
+                  >
+                    <span className="font-medium">{item.ingredient.name}</span>
+                    <span className="text-muted-foreground">
+                      {item.quantity} {item.unit}
+                    </span>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="flex justify-end pt-4 border-t mt-4">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Close
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  )
+}


### PR DESCRIPTION
### Motivation
- Provide a read-only way to inspect a meal's details and ingredients from the meal library without entering the edit flow.

### Description
- Add a new `ViewMealDialog` component (`app/meals/view-meal-dialog.tsx`) that fetches and displays a meal's category, description, weeknight-friendly badge, and ingredients in a read-only dialog. 
- Wire a View action into the meal cards in `app/meals/page.tsx` by importing an `Eye` icon, adding `mealToView` state, and opening the dialog when the new View button is clicked.
- Keep existing Edit/Delete actions and ensure the view dialog closes cleanly via the dialog API.

### Testing
- Started the Next.js dev server with `npm run dev` and confirmed compilation of pages (e.g. `/auth`) during local dev run. Compilation succeeded for the pages served in the environment. 
- Attempted an end-to-end check with a Playwright script that signs in (using `USERNAME`/`PASSWORD` env vars), navigates to `/meals`, and clicks the new View button, but the Playwright run failed due to the headless Chromium crash / environment browser issues and a navigation timeout, so the UI interaction could not be fully validated in this environment.
- No unit tests were added or run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983ca2e7bc0832ea3a8a510bc6400fb)